### PR TITLE
Potential fix for code scanning alert no. 3: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -34,13 +34,13 @@ class TestPedantic < Minitest::Test
 
   def test_heuristics_are_sorted
     file = File.expand_path("../../lib/linguist/heuristics.rb", __FILE__)
-    heuristics = open(file).each.grep(/^ *disambiguate/)
+    heuristics = File.open(file) { |f| f.each_line.grep(/^ *disambiguate/) }
     assert_sorted heuristics
   end
 
   def test_heuristics_tests_are_sorted
     file = File.expand_path("../test_heuristics.rb", __FILE__)
-    tests = open(file).each.grep(/^ *def test_[a-z_]+_by_heuristics/)
+    tests = File.open(file) { |f| f.each_line.grep(/^ *def test_[a-z_]+_by_heuristics/) }
     assert_sorted tests
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/XDMtM69/linguist/security/code-scanning/3](https://github.com/XDMtM69/linguist/security/code-scanning/3)

To fix the issue, replace the use of `open(file)` with `File.open(file)` in the affected lines. This ensures that the code does not invoke `Kernel.open`, thereby mitigating the risk of executing unintended shell commands. Additionally, since the code is reading the file line by line, the `File.open` block should be used with an enumerator to maintain the same functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
