### PR TITLE
Potential fix for code scanning alert no. 2: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/test/test_pedantic.rb
+++ b/test/test_pedantic.rb
@@ -34,13 +34,13 @@ class TestPedantic < Minitest::Test
 
   def test_heuristics_are_sorted
     file = File.expand_path("../../lib/linguist/heuristics.rb", __FILE__)
-    heuristics = open(file).each.grep(/^ *disambiguate/)
+    heuristics = File.open(file) { |f| f.each.grep(/^ *disambiguate/) }
     assert_sorted heuristics
   end
 
   def test_heuristics_tests_are_sorted
     file = File.expand_path("../test_heuristics.rb", __FILE__)
-    tests = open(file).each.grep(/^ *def test_[a-z_]+_by_heuristics/)
+    tests = File.open(file) { |f| f.each.grep(/^ *def test_[a-z_]+_by_heuristics/) }
     assert_sorted tests
   end
 


### PR DESCRIPTION
Potential fix for [https://github.com/XDMtM69/linguist/security/code-scanning/2](https://github.com/XDMtM69/linguist/security/code-scanning/2)

To fix the issue, replace the use of `open(file)` with `File.open(file)` in the `test_heuristics_are_sorted` and `test_heuristics_tests_are_sorted` methods. Since the code is reading lines from the file, we will use `File.open` with a block to safely handle the file and ensure it is closed after reading. This change maintains the existing functionality while addressing the security concern.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
