### PR TITLE
Potential fix for code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/test/test_generated.rb
+++ b/test/test_generated.rb
@@ -17,7 +17,7 @@ class TestGenerated < Minitest::Test
     assert_raises(DataLoadedError, "Data wasn't loaded when calling generated? on #{blob}") do
       Generated.generated?(blob, lambda { raise DataLoadedError.new })
     end
-    assert Generated.generated?(blob, lambda { IO.read(blob) }), "#{blob} was not recognized as a generated file"
+    assert Generated.generated?(blob, lambda { File.read(blob) }), "#{blob} was not recognized as a generated file"
   end
 
   def generated_fixture_without_loading_data(name)


### PR DESCRIPTION
Potential fix for [https://github.com/XDMtM69/linguist/security/code-scanning/1](https://github.com/XDMtM69/linguist/security/code-scanning/1)

To fix the flagged issue, replace `IO.read(blob)` with `File.read(blob)` in the test file. This ensures that even if the filename is somehow manipulated, there is no risk of executing arbitrary shell commands. No additional imports or helper methods are needed, as `File.read` is in the Ruby standard library. Only line 20 in `test/test_generated.rb` needs to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
