### PR TITLE
Potential fix for code scanning alert no. 5: Overly permissive regular expression range

### DIFF
--- a/samples/Ruby/sinatra.rb
+++ b/samples/Ruby/sinatra.rb
@@ -180,7 +180,7 @@ module Sinatra
     # Generates the absolute URI for a given path in the app.
     # Takes Rack routers and reverse proxies into account.
     def uri(addr = nil, absolute = true, add_script_name = true)
-      return addr if addr =~ /\A[A-z][A-z0-9\+\.\-]*:/
+      return addr if addr =~ /\A[A-Za-z][A-Za-z0-9\+\.\-]*:/
       uri = [host = ""]
       if absolute
         host << "http#{'s' if request.secure?}://"


### PR DESCRIPTION
Potential fix for [https://github.com/XDMtM69/linguist/security/code-scanning/5](https://github.com/XDMtM69/linguist/security/code-scanning/5)

The fix is to change the regular expression in the `uri` helper method from `/\A[A-z][A-z0-9\+\.\-]*:/` to `/\A[A-Za-z][A-Za-z0-9\+\.\-]*:/`. This ensures that only valid ASCII letters are matched in the URI scheme, as specified by RFC 3986. The change should be made specifically in the regular expression at line 183 of `samples/Ruby/sinatra.rb`. No additional imports or dependencies are required, as Ruby's built-in regular expressions are sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
