### PR TITLE
Update Gemfile.lock

### DIFF
--- a/samples/Ruby/filenames/Gemfile.lock
+++ b/samples/Ruby/filenames/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rake (10.3.2)
+    rake (10.3.3)
     rugged (0.22.0b1)
     slop (3.6.0)
     yajl-ruby (1.2.1)


### PR DESCRIPTION
This change resolves the OS Command Injection vulnerability in the rake gem (reported by Dependabot).

The Gemfile.lock is updated to version 12.3.3, which contains the security patch.