### PR TITLE
Update Gemfile.lock

### DIFF
--- a/samples/Ruby/filenames/Gemfile.lock
+++ b/samples/Ruby/filenames/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    rake (10.3.3)
+    rake (12.3.3)
     rugged (0.22.0b1)
     slop (3.6.0)
     yajl-ruby (1.3.1)


### PR DESCRIPTION

### Summary

This pull request addresses the OS Command Injection vulnerability in the rake gem, as identified by Dependabot alert #55. The previous version of Rake (10.3.3) was affected by this security issue.

### Changes Made

- **Updated rake gem:** The version of rake has been upgraded to 12.3.3 in Gemfile.lockPatched Vulnerability:y:** This update effectively patches the vulnerability in Rake::FileList where a command could be executed if a filename starts with a pipe character |.

### RelatedCloses:s:** Dependabot alert #5Reference:e:** The vulnerability details can be found on GitHub and the Rake gem's security advisory.

This change is critical for maintaining the security of the project.