### PR TITLE
Update Gemfile.lock

### DIFF
--- a/samples/Ruby/filenames/Gemfile.lock
+++ b/samples/Ruby/filenames/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
     rake (12.3.3)
     rugged (0.22.0b1)
     slop (3.6.0)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.3)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
### Summary

This pull request addresses the Buffer Overflow vulnerability in the yajl-ruby gem, as identified by Dependabot alert #56. The previous version (1.3.1) was affected by this security issue.

### Changes Made

- **Updated yajl-ruby gem:** The version of yajl-ruby has been upgraded to 1.4.3 in Gemfile.lockPatched Vulnerability:y:** This update effectively patches the integer overflow vulnerability that could lead to heap memory corruption and potential Denial of Service (DoS) attacks when handling large inputs.

### RelatedCloses:s:** Dependabot alert #5Reference:e:** The vulnerability details can be found on GitHub and the yajl-ruby gem's security advisory.

This change is critical for maintaining the security and stability of the project.